### PR TITLE
exemplo refatorar exceção

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from src.img.criaPastas import criaPastas
 from src.rotas.evento.eventoRotas import roteador as roteadorEvento
 from src.rotas.petiano.petianoRotas import roteador as roteadorPetianos
 from src.rotas.usuario.usuarioRotas import roteador as roteadorUsuario
+from src.middleware import request_handler
 
 logging.basicConfig(
     handlers=[
@@ -23,6 +24,7 @@ locale.setlocale(locale.LC_ALL, "pt_BR.UTF-8")
 criaPastas()
 
 petBack = FastAPI()
+petBack.middleware("http")(request_handler)
 petBack.include_router(roteadorUsuario)
 petBack.include_router(roteadorPetianos)
 petBack.include_router(roteadorEvento)

--- a/src/email/operacoesEmail.py
+++ b/src/email/operacoesEmail.py
@@ -6,35 +6,35 @@ from email.message import EmailMessage
 # Função para enviar email customizado
 def emailGenerico(
     emailPet: str, senhaPet: str, emailDestino: str, titulo: str, texto: str
-) -> dict:
+):
     mensagem: EmailMessage = EmailMessage()
     mensagem["From"] = emailPet
     mensagem["To"] = emailDestino
     mensagem["Subject"] = titulo
     mensagem.set_content(texto)
 
-    return enviarEmail(emailPet, senhaPet, emailDestino, mensagem)
+    enviarEmail(emailPet, senhaPet, emailDestino, mensagem)
 
 
 # Função para enviar verificação de email
-def verificarEmail(emailPet: str, senhaPet: str, emailDestino: str, link: str) -> dict:
+def verificarEmail(emailPet: str, senhaPet: str, emailDestino: str, link: str):
     mensagem: EmailMessage = EmailMessage()
     mensagem["From"] = emailPet
     mensagem["To"] = emailDestino
     mensagem["Subject"] = "Pet-Info - Verficação de Conta"
     mensagem.set_content("Clique no link para verificar sua conta: " + link)
 
-    return enviarEmail(emailPet, senhaPet, emailDestino, mensagem)
+    enviarEmail(emailPet, senhaPet, emailDestino, mensagem)
 
 
 # Função para enviar link troca de senha
-def resetarSenha(emailPet: str, senhaPet: str, emailDestino: str, link: str) -> dict:
+def resetarSenha(emailPet: str, senhaPet: str, emailDestino: str, link: str):
     mensagem: EmailMessage = EmailMessage()
     mensagem["From"] = emailPet
     mensagem["To"] = emailDestino
     mensagem["Subject"] = "PET-Info - Reset de senha"
     mensagem.set_content("Para resetar sua senha, acesse o link: " + link)
-    return enviarEmail(emailPet, senhaPet, emailDestino, mensagem)
+    enviarEmail(emailPet, senhaPet, emailDestino, mensagem)
 
 
 # Função que envia email para avisar sobre inscrição do evento
@@ -62,20 +62,15 @@ def emailConfirmacaoEvento(
         + evento["pré-requisitos"]
     )
 
-    return enviarEmail(emailPet, senhaPet, emailDestino, mensagem)
+    enviarEmail(emailPet, senhaPet, emailDestino, mensagem)
 
 
 # Função que faz o envio de emails
 def enviarEmail(
     emailPet: str, senhaPet: str, emailDestino: str, mensagem: EmailMessage
-) -> dict:
-    try:
-        contexto: ssl.SSLContext = ssl.create_default_context()
+) -> None:
+    contexto: ssl.SSLContext = ssl.create_default_context()
 
-        with smtplib.SMTP_SSL("smtp.gmail.com", 465, context=contexto) as smtp:
-            smtp.login(emailPet, senhaPet)
-            smtp.sendmail(emailPet, emailDestino, mensagem.as_string())
-
-        return {"mensagem": "Email enviado com sucesso", "status": "200"}
-    except:
-        return {"mensagem": "Falha ao enviar o email", "status": "400"}
+    with smtplib.SMTP_SSL("smtp.gmail.com", 465, context=contexto) as smtp:
+        smtp.login(emailPet, senhaPet)
+        smtp.sendmail(emailPet, emailDestino, mensagem.as_string())

--- a/src/middleware.py
+++ b/src/middleware.py
@@ -1,0 +1,14 @@
+from fastapi import Request, status
+from fastapi.responses import JSONResponse
+
+from src.modelos.exceptions import APIExcecaoBase
+
+
+async def request_handler(request: Request, call_next):
+    try:
+        return await call_next(request)
+    except Exception as ex:
+        if isinstance(ex, APIExcecaoBase):
+            return ex.response()
+
+        raise ex

--- a/src/modelos/erros.py
+++ b/src/modelos/erros.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, Field
+
+
+class ErroBase(BaseModel):
+    message: str = Field(..., description="A mensagem ou descrição do erro.")
+    etc: str = "oi"
+
+
+class NaoEncontradoErro(ErroBase):
+    pass
+
+
+class JaExisteErro(ErroBase):
+    pass

--- a/src/modelos/exceptions.py
+++ b/src/modelos/exceptions.py
@@ -1,0 +1,43 @@
+from fastapi import status
+from fastapi.responses import JSONResponse
+
+from src.modelos.erros import ErroBase, JaExisteErro
+
+from typing import Type
+
+
+class APIExcecaoBase(Exception):
+    message = "Erro genérico."
+    code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    model = ErroBase
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("message", self.message)
+        self.message = kwargs["message"]
+        self.data = self.model(**kwargs)
+
+    def response(self):
+        return JSONResponse(content=self.data.dict(), status_code=self.code)
+
+    @classmethod
+    def response_model(cls):
+        return {cls.code: {"model": cls.model}}
+
+
+class JaExisteExcecao(APIExcecaoBase):
+    message = "A entidade já existe."
+    code = status.HTTP_409_CONFLICT
+    model = JaExisteErro
+
+
+class UsuarioJaExisteExcecao(JaExisteExcecao):
+    message = "O usuário já existe."
+
+
+def get_exception_responses(*args: Type[APIExcecaoBase]) -> dict:
+    """Given BaseAPIException classes, return a dict of responses used on FastAPI endpoint definition, with the format:
+    {statuscode: schema, statuscode: schema, ...}"""
+    responses = dict()
+    for cls in args:
+        responses.update(cls.response_model())
+    return responses

--- a/src/modelos/usuario/usuarioBD.py
+++ b/src/modelos/usuario/usuarioBD.py
@@ -1,6 +1,7 @@
 from bson.objectid import ObjectId
 from pymongo import MongoClient
 from pymongo.errors import DuplicateKeyError
+from src.modelos.exceptions import UsuarioJaExisteExcecao
 
 from src.modelos.usuario.usuarioValidator import ValidarUsuario
 
@@ -12,18 +13,15 @@ class UsuarioBD:
         self.__colecao = db["usuarios"]
         self.__validarDados = ValidarUsuario().usuario()
 
-    def criarUsuario(self, dadoUsuario: object) -> dict:
+    def criarUsuario(self, dadoUsuario: object) -> str:
         if self.__validarDados.validate(dadoUsuario):
             try:
                 resultado = self.__colecao.insert_one(dadoUsuario)
-                return {
-                    "mensagem": resultado.inserted_id,
-                    "status": "200",
-                }
-            except DuplicateKeyError:
-                return {"mensagem": "CPF ou email já existem", "status": "409"}
+                return str(resultado.inserted_id)
+            except DuplicateKeyError as ex:
+                raise UsuarioJaExisteExcecao(message="teste")
         else:
-            return {"mensagem": self.__validarDados.errors, "status": "400"}
+            raise Exception(self.__validarDados.errors)
 
     def deletarUsuario(self, idUsuario: str) -> dict:
         idUsuario = ObjectId(idUsuario)

--- a/src/rotas/usuario/usuarioRotas.py
+++ b/src/rotas/usuario/usuarioRotas.py
@@ -13,6 +13,7 @@ from fastapi import (
 )
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr, HttpUrl, SecretStr
+from src.modelos.exceptions import UsuarioJaExisteExcecao, get_exception_responses
 
 from src.modelos.autenticacao.autenticacaoTokenBD import AuthTokenBD
 from src.modelos.usuario.usuario import Usuario, UsuarioSenha
@@ -47,6 +48,7 @@ roteador = APIRouter(
     " - Deve ter ao menos um dígito\n"
     " - Deve ter ao menos um caractere não alfanumérico\n",
     status_code=status.HTTP_201_CREATED,
+    responses=get_exception_responses(UsuarioJaExisteExcecao),
 )
 def cadastrarUsuario(
     nomeCompleto: Annotated[str, Form(max_length=200)],
@@ -77,6 +79,7 @@ def cadastrarUsuario(
     cpf = "".join(c for c in cpf if c in "0123456789")
 
     # despacha para controlador
+    # try:
     resultado = cadastraUsuarioControlador(
         nomeCompleto=nomeCompleto,
         cpf=cpf,
@@ -84,17 +87,8 @@ def cadastrarUsuario(
         senha=senha.get_secret_value(),
         curso=curso,
     )
-    if resultado["status"] != "201":
-        logging.info(
-            "Tentativa de cadastro de usuário falhou. Dados: "
-            + str(resultado["mensagem"])
-        )
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Dados inválidos"
-        )
 
-    # retorna OK
-    return resultado["mensagem"]
+    return resultado
 
 
 @roteador.get(


### PR DESCRIPTION
Atualmente a nossa arquitetura é assim:
- uma função interna realiza uma tarefa, e indica sucesso ou fracasso com um dict
- o dict tem dois campos, status e mensagem, que podem ter etc etc. 
- as funções garantidamente não levantam exceções; fracasso é indicado pelo dict de retorno.

Problemas com essa arquitetura:
- não tem como indicar na tipagem quais são os tipos que podem aparecer em "mensagem";
- a verificação de erros está espalhada no código inteiro ao invés de um lugar só;
- é completamente desnecessário também porque se ALGUMA operação der errado, muito provavelmente a chamada da API inteira vai fracassar;
- cada função pode retornar um status de sucesso diferente; também pode retornar N status de fracasso diferentes. Tem que ficar escrevendo e lendo documentação pra ver o que acontece;
- o python tem mecanismos pra indicar que algo deu errado que a gente não está usando.

A proposta:
- adotar um modelo "fail fast" pro código;
- quando um problema acontece, levanta uma Exception indicando isso; a Exception vai subir até o API e indicar pro usuário que algo deu errado;
- as funções agora retornam tipos concretos ao invés de dicts, e levantam Exceptions quando dá erro

Na prática:
- definir várias classes que herdam de Exception

class ConexaoFechadaException(Exception):

- se uma função podia retornar um objeto T ou não (e o objeto não existir NÃO É ERRO), agora o retorno dela é

def fun(...) -> T | None:

- se a função é pra retornar um objeto T sempre e só não retorna em caso de erro, agora o retorno dela é:

def fun(...) -> T:

- caso um problema ocorra durante uma função, mete um raise:

raise ConexaoFechadaException("etc")

- Pra não brotar um Erro 500 opaco na API, tem que cadastrar um middleware que converte a Exception pra um formato de texto amigável. Tem um exemplo no repositório linkado. Alternativamente teria que botar um try/except em cada API e fazer o mapeamento, mas isso não é prático.

- Lembrar de pôr as exceções que podem brotar numa API no campo de respostas possíveis da anotação


---

O que eu fiz aqui:
1. "Achatei" o API de cadastrar o usuário, removendo dicts em todas as funções do caminho e fazendo ele arremessar exceções
2. Defini alguns tipos de exceções e modelos de erro
3. Associei os erros às exceções
4. Cadastrei um middleware que recupera os modelos das exceções e mostra de modo amigável ao usuário
5. Entre outras coisas que eu não lembro agora

