### PR TITLE
Corrige o envio de fotos pelo servidor

### DIFF
--- a/src/modelos/bd.py
+++ b/src/modelos/bd.py
@@ -64,14 +64,14 @@ class UsuarioBD:
         colecaoUsuarios.delete_one({"_id": id})
 
     @staticmethod
-    def listar(petiano: bool = False) -> list[Usuario]:
-        if not petiano:
-            return [Usuario(**u) for u in colecaoUsuarios.find()]
-        else:
-            return [
-                Usuario(**u)
-                for u in colecaoUsuarios.find({"tipoConta": TipoConta.PETIANO})
-            ]
+    def listar() -> list[Usuario]:
+        return [Usuario(**u) for u in colecaoUsuarios.find()]
+
+    @staticmethod
+    def listarPetianos() -> list[Usuario]:
+        return [
+            Usuario(**u) for u in colecaoUsuarios.find({"tipoConta": TipoConta.PETIANO})
+        ]
 
 
 class EventoBD:

--- a/src/modelos/usuario/usuarioClad.py
+++ b/src/modelos/usuario/usuarioClad.py
@@ -37,7 +37,6 @@ class UsuarioLer(BaseModel):
     email: EmailStr
     curso: str
 
-    foto: str | None = None
     github: str | None = None
     linkedin: str | None = None
     instagram: str | None = None

--- a/src/rotas/usuario/usuarioControlador.py
+++ b/src/rotas/usuario/usuarioControlador.py
@@ -205,8 +205,23 @@ class UsuarioControlador:
         raise UsuarioNaoEncontradoExcecao()
 
     @staticmethod
-    def getUsuarios(petiano: bool = False) -> list[Usuario]:
-        return UsuarioBD.listar(petiano)
+    def getUsuarios() -> list[Usuario]:
+        return UsuarioBD.listar()
+
+    @staticmethod
+    def getPetianos() -> list[Petiano]:
+        petianos = []
+        for petiano in UsuarioBD.listarPetianos():
+            petianos.append(
+                Petiano(
+                    nome=petiano.nome,
+                    github=petiano.github,
+                    linkedin=petiano.linkedin,
+                    instagram=petiano.instagram,
+                    foto=f"{config.CAMINHO_BASE}/img/usuarios/{petiano.id}/foto",
+                )
+            )
+        return petianos
 
     @staticmethod
     def editarUsuario(
@@ -289,7 +304,9 @@ class UsuarioControlador:
             usuario.emailConfirmado = False
 
             UsuarioBD.atualizar(usuario)
-            mensagemEmail: str = f"{config.CAMINHO_BASE}/usuarios/confirma-email?token={geraTokenAtivaConta(usuario.id, usuario.email, timedelta(hours=24))}"
+            mensagemEmail: str = (
+                f"{config.CAMINHO_BASE}/usuarios/confirma-email?token={geraTokenAtivaConta(usuario.id, usuario.email, timedelta(hours=24))}"
+            )
 
             tasks.add_task(enviarEmailVerificacao, usuario.email, mensagemEmail)
             tasks.add_task(enviarEmailAlteracaoDados, emailAntigo, DadoAlterado.EMAIL)

--- a/src/rotas/usuario/usuarioRotas.py
+++ b/src/rotas/usuario/usuarioRotas.py
@@ -28,7 +28,7 @@ from src.modelos.excecao import (
     listaRespostasExcecoes,
 )
 from src.modelos.registro.registroLogin import RegistroLogin
-from src.modelos.usuario.usuario import TipoConta, Usuario
+from src.modelos.usuario.usuario import Petiano, TipoConta, Usuario
 from src.modelos.usuario.usuarioClad import (
     UsuarioAtualizar,
     UsuarioAtualizarEmail,
@@ -114,10 +114,10 @@ def listarUsuarios(
     "/petiano",
     name="Recuperar petianos cadastrados",
     description="Lista todos os petianos cadastrados.",
-    response_model=list[UsuarioLer],
+    response_model=list[Petiano],
 )
 def listarPetianos():
-    return UsuarioControlador.getUsuarios(petiano=True)
+    return UsuarioControlador.getPetianos()
 
 
 @roteador.get(
@@ -326,7 +326,7 @@ def editarFoto(
     description="Promove o usuário especificado a petiano.",
 )
 def promoverPetiano(
-    id: str, _usuario: Annotated[Usuario, Depends(getPetianoAutenticado)] = ... 
+    id: str, _usuario: Annotated[Usuario, Depends(getPetianoAutenticado)] = ...
 ):
     UsuarioControlador.promoverPetiano(id)
 


### PR DESCRIPTION
Antes o servidor enviava os caminhos internos das imagens armazenadas nele. Agora isso não acontece mais; se necessário, o servidor acrescenta um link para a rota de recuperação de imagens (já existente).