### PR TITLE
conserta retorno evento

### DIFF
--- a/src/modelos/evento/eventoClad.py
+++ b/src/modelos/evento/eventoClad.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Self
 
-from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, field_validator, Field, model_validator
 
 from src.modelos.evento.evento import Evento
 
@@ -52,6 +52,12 @@ class EventoCriar(BaseModel):
 
 
 class EventoLer(Evento):
+    # id requerido por causa do seguinte bug
+    # https://github.com/pydantic/pydantic/issues/1869
+    
+    id: str
+    "Identificador único."
+    
     pass
 
 

--- a/src/rotas/evento/eventoRotas.py
+++ b/src/rotas/evento/eventoRotas.py
@@ -19,9 +19,10 @@ roteador = APIRouter(prefix="/eventos", tags=["Eventos"])
     "/",
     name="Recuperar eventos",
     description="Retorna todos os eventos cadastrados no banco de dados filtrados pelo parâmetro 'query'.",
+    response_model=list[EventoLer],
 )
-def getEventos(query: eventoQuery) -> list[Evento]:
-    return EventoControlador.getEventos(query)
+def getEventos(query: eventoQuery) -> list[EventoLer]:
+    return [EventoLer(**e.model_dump()) for e in EventoControlador.getEventos(query)]
 
 
 @roteador.get(
@@ -33,10 +34,8 @@ def getEventos(query: eventoQuery) -> list[Evento]:
     """,
     response_model=EventoLer,
 )
-def getEvento(id: str) -> Evento:
-    evento: Evento = EventoControlador.getEvento(id)
-
-    return evento
+def getEvento(id: str) -> EventoLer:
+    return EventoLer(**EventoControlador.getEvento(id).model_dump())
 
 
 @roteador.post(


### PR DESCRIPTION
Os retornos dos eventos estavam com o campo _id, pois o pydantic não estava reconhecendo o alias 