### PR TITLE
Caio gui pam cadastrar inscrito comprovante

### DIFF
--- a/src/rotas/evento/eventoControlador.py
+++ b/src/rotas/evento/eventoControlador.py
@@ -2,7 +2,7 @@ import logging
 import secrets
 from typing import BinaryIO
 from bson.objectid import ObjectId
-from fastapi import UploadFile
+from fastapi import File, UploadFile
 
 # Importações dos módulos internos
 from src.config import config
@@ -246,8 +246,9 @@ class EventoControlador:
         idUsuario: str,
         dadosInscrito: InscritoCriar,
         comprovante: UploadFile | None,
-        tasks: BackgroundTasks,
+        tasks: BackgroundTasks,  
     ):
+        print("Função cadastrarInscrito foi chamada!")  # <- Print inicial para verificar
         """
         Cadastra um inscrito em um evento.
 
@@ -280,8 +281,10 @@ class EventoControlador:
         else:
             if evento.vagasDisponiveisSemNote == 0:
                 raise APIExcecaoBase(message="Não há vagas disponíveis sem note")
-
+        
+        print(f"Valor do evento: {evento.valor} (Tipo: {type(evento.valor)})")
         if evento.valor != 0:
+            print("Evento pago")
             if comprovante:
                 if not validaComprovante(comprovante.file):
                     raise APIExcecaoBase(message="Comprovante inválido.")
@@ -295,6 +298,9 @@ class EventoControlador:
                     message="Comprovante obrigatório para eventos pagos."
                 )
         else:
+            print("Evento gratuito")
+            print("Comprovante recebido:", comprovante)
+            print("Tipo do comprovante:", type(comprovante))
             caminhoComprovante = None
 
         dictInscrito = {

--- a/src/rotas/evento/eventoControlador.py
+++ b/src/rotas/evento/eventoControlador.py
@@ -248,7 +248,6 @@ class EventoControlador:
         comprovante: UploadFile | None,
         tasks: BackgroundTasks,  
     ):
-        print("Função cadastrarInscrito foi chamada!")  # <- Print inicial para verificar
         """
         Cadastra um inscrito em um evento.
 
@@ -282,9 +281,7 @@ class EventoControlador:
             if evento.vagasDisponiveisSemNote == 0:
                 raise APIExcecaoBase(message="Não há vagas disponíveis sem note")
         
-        print(f"Valor do evento: {evento.valor} (Tipo: {type(evento.valor)})")
         if evento.valor != 0:
-            print("Evento pago")
             if comprovante:
                 if not validaComprovante(comprovante.file):
                     raise APIExcecaoBase(message="Comprovante inválido.")
@@ -298,9 +295,6 @@ class EventoControlador:
                     message="Comprovante obrigatório para eventos pagos."
                 )
         else:
-            print("Evento gratuito")
-            print("Comprovante recebido:", comprovante)
-            print("Tipo do comprovante:", type(comprovante))
             caminhoComprovante = None
 
         dictInscrito = {

--- a/src/rotas/evento/eventoRotas.py
+++ b/src/rotas/evento/eventoRotas.py
@@ -169,10 +169,6 @@ def cadastrarInscrito(
     :param inscrito: Dados de um inscrito.
     :param comprovante: Arquivo de comprovante de pagamento.
     """
-    print("entra na rota cadastrarInscrito")
-    print(f"Tipo do comprovante: {type(comprovante)}")
-    print(f"Valor do comprovante: {comprovante}")
-    
     if comprovante == "":
         comprovante = None
         

--- a/src/rotas/evento/eventoRotas.py
+++ b/src/rotas/evento/eventoRotas.py
@@ -158,7 +158,7 @@ def cadastrarInscrito(
     usuario: Annotated[Usuario, Depends(getUsuarioAutenticado)],
     idEvento: str,
     inscrito: InscritoCriar = Depends(),
-    comprovante: UploadFile | None = None,
+    comprovante: UploadFile | str | None = None,
 ):
     """
     Cadastra um inscrito em um evento.
@@ -169,6 +169,13 @@ def cadastrarInscrito(
     :param inscrito: Dados de um inscrito.
     :param comprovante: Arquivo de comprovante de pagamento.
     """
+    print("entra na rota cadastrarInscrito")
+    print(f"Tipo do comprovante: {type(comprovante)}")
+    print(f"Valor do comprovante: {comprovante}")
+    
+    if comprovante == "":
+        comprovante = None
+        
     # Despacha para o controlador
     EventoControlador.cadastrarInscrito(    
         idEvento, usuario.id, inscrito, comprovante, tasks


### PR DESCRIPTION
Agora é possível criar um inscrito em um evento gratuito sem a necessidade de enviar um comprovante.
Sugestões de testes:
-Criar um inscrito em um evento gratuito com e sem comprovante.
-Criar um inscrito em um evento pago com e sem comprovante.
-Verificar se é possível inscrever várias pessoas em um evento sem problemas.