### PR TITLE
Adiciona enum "Genero" ao modelo de usuário

### DIFF
--- a/src/modelos/usuario/usuario.py
+++ b/src/modelos/usuario/usuario.py
@@ -25,6 +25,28 @@ class TipoConta(str, Enum):
     ADMIN = "admin"
     "Conta pertencente ao grupo PET-Informática. Possui permissões totais."
 
+
+class Genero(str, Enum):
+    """
+    Gênero do usuário.
+    """
+
+    MASCULINO = "masculino"
+    "Masculino."
+
+    FEMININO = "feminino"
+    "Feminino."
+
+    NAO_BINARIO = "não-binário"
+    "Não-binário."
+
+    OUTRO = "outro"
+    "Outro."
+
+    PREFIRO_NAO_DIZER = "prefiro não dizer"
+    "Prefiro não dizer."
+
+
 class Usuario(BaseModel):
     """
     Classe que representa um usuário do sistema.
@@ -54,7 +76,7 @@ class Usuario(BaseModel):
     tipoConta: TipoConta
     "Tipo de conta. Representa permissões."
 
-    genero: str | None = None
+    genero: Genero | None = None
     "Gênero do usuário"
 
     dataNascimento: datetime | None = None

--- a/src/modelos/usuario/usuarioClad.py
+++ b/src/modelos/usuario/usuarioClad.py
@@ -7,7 +7,7 @@ from typing import Annotated
 
 from pydantic import BaseModel, EmailStr, SecretStr, StringConstraints, field_validator
 
-from src.modelos.usuario.usuario import TipoConta
+from src.modelos.usuario.usuario import Genero, TipoConta
 from src.modelos.usuario.validacaoCadastro import ValidacaoCadastro
 
 
@@ -24,7 +24,7 @@ class UsuarioCriar(BaseModel):
     cpf: str
     """CPF do usuário. O CPF deve ser válido."""
 
-    genero: str
+    genero: Genero
     """Gênero do usuário."""
 
     dataNascimento: datetime
@@ -84,7 +84,7 @@ class UsuarioLer(BaseModel):
     curso: str
     """Curso do usuário."""
 
-    genero: str
+    genero: Genero
     """Gênero do usuário"""
 
     dataNascimento: datetime
@@ -119,7 +119,7 @@ class UsuarioLerAdmin(UsuarioLer):
     emailConfirmado: bool
     """Indica se o e-mail do usuário foi confirmado."""
 
-    genero: str
+    genero: Genero
     """Gênero do usuário"""
 
     dataNascimento: datetime
@@ -158,7 +158,7 @@ class UsuarioAtualizar(BaseModel):
     curso: str | None = None
     """Curso do usuário."""
 
-    genero: str | None = None
+    genero: Genero | None = None
     """Gênero do usuário"""
 
     dataNascimento: datetime | None = None


### PR DESCRIPTION
Adiciona o enum "Genero" com as opções "Masculino", "Feminino", "Não-binário", "Outro" e "Prefiro não dizer", substituindo o "str" utilizado anteriormente no modelo e nos clads.