### PR TITLE
Correções na listagem de eventos inscritos

### DIFF
--- a/src/modelos/usuario/usuario.py
+++ b/src/modelos/usuario/usuario.py
@@ -47,6 +47,21 @@ class Genero(str, Enum):
     "Prefiro não dizer."
 
 
+class EventoResumido(BaseModel):
+    """
+    Resumo de um Evento para consultas dos Petianos.
+    """
+
+    id: str
+    "Identificador único."
+
+    titulo: str
+    "Título do evento."
+
+    arte: str | None
+    "Caminho para a imagem de capa do evento."
+
+
 class Usuario(BaseModel):
     """
     Classe que representa um usuário do sistema.
@@ -153,8 +168,8 @@ class Petiano(BaseModel):
     tipoConta: TipoConta | None = None
     "Tipo de conta. Representa petianos ou egressos"
 
-    eventosInscrito: list[str] = []
-    "Lista de tuplas de id de evento."
+    eventosInscrito: list[EventoResumido] = []
+    "Lista com informações resumidas de um Evento."
 
     apadrinhadoPor: str | None = None
     "Id do petiano que apadrinhou este petiano."

--- a/src/rotas/usuario/usuarioControlador.py
+++ b/src/rotas/usuario/usuarioControlador.py
@@ -24,7 +24,7 @@ from src.email.operacoesEmail import (
     enviarEmailVerificacao,
 )
 from src.img.operacoesImagem import armazenaFotoUsuario, deletaImagem, validaImagem
-from src.modelos.bd import RegistroLoginBD, TokenAutenticacaoBD, UsuarioBD, cliente
+from src.modelos.bd import EventoBD, RegistroLoginBD, TokenAutenticacaoBD, UsuarioBD, cliente
 from src.modelos.excecao import (
     APIExcecaoBase,
     EmailNaoConfirmadoExcecao,
@@ -280,6 +280,23 @@ class UsuarioControlador:
             urlFoto = None
             if petiano.foto:
                 urlFoto = f"{config.CAMINHO_BASE}/img/usuarios/{petiano.id}/foto"
+
+            eventos = []
+            for evento_id in petiano.eventosInscrito:
+                try:
+                    evento = EventoBD.buscar("_id", evento_id)
+                    url_arte = (
+                        f"{config.CAMINHO_BASE}/img/eventos/{evento.id}/arte"
+                        if evento.arte
+                        else None
+                    )
+                    eventos.append({
+                        "id": evento.id,
+                        "titulo": evento.titulo,
+                        "arte": url_arte,
+                    })
+                except Exception:
+                    pass  
             
             # adiciona o petiano à lista
             petianos.append(
@@ -293,7 +310,7 @@ class UsuarioControlador:
                     inicioPet=petiano.inicioPet,
                     fimPet=petiano.fimPet,
                     sobre=petiano.sobre,
-                    eventosInscrito=petiano.eventosInscrito,
+                    eventosInscrito=eventos,
                     tipoConta=petiano.tipoConta,
                     apadrinhadoPor=petiano.apadrinhadoPor,
                 )
@@ -314,6 +331,23 @@ class UsuarioControlador:
             if petiano.foto:
                 urlFoto = f"{config.CAMINHO_BASE}/img/usuarios/{petiano.id}/foto"
             
+            eventos = []
+            for evento_id in petiano.eventosInscrito:
+                try:
+                    evento = EventoBD.buscar("_id", evento_id)
+                    url_arte = (
+                        f"{config.CAMINHO_BASE}/img/eventos/{evento.id}/arte"
+                        if evento.arte
+                        else None
+                    )
+                    eventos.append({
+                        "id": evento.id,
+                        "titulo": evento.titulo,
+                        "arte": url_arte,
+                    })
+                except Exception:
+                    pass  
+
             # adiciona o petiano ou egresso à lista
             petianos.append(
                 Petiano(
@@ -326,7 +360,7 @@ class UsuarioControlador:
                     inicioPet=petiano.inicioPet,
                     fimPet=petiano.fimPet,
                     sobre=petiano.sobre,
-                    eventosInscrito=petiano.eventosInscrito,
+                    eventosInscrito=eventos,
                     tipoConta=petiano.tipoConta,
                     apadrinhadoPor=petiano.apadrinhadoPor,
                 )


### PR DESCRIPTION
Adaptação necessária para a página de Petianos.
Enviar uma lista de IDs de Eventos em vez dos Eventos em si é prejudicial ao Front-End, que precisaria realizar diversas requisições ao Back-End e descartar a maioria das informações recuperadas. Dessa forma, enviar uma lista de Eventos resumidos é uma boa opção para corrigir esse problema.